### PR TITLE
Make project_root work with submodules

### DIFF
--- a/lib/aid.rb
+++ b/lib/aid.rb
@@ -40,9 +40,10 @@ module Aid
       current_search_dir = Dir.pwd
 
       loop do
-        git_dir = "#{current_search_dir}/.git"
+        git_index = "#{current_search_dir}/.git"
+        git_index_exists = Dir.exist?(git_index) || File.exist?(git_index)
 
-        return current_search_dir if Dir.exist?(git_dir)
+        return current_search_dir if git_index_exists
         break if current_search_dir == '/'
 
         current_search_dir = File.expand_path("#{current_search_dir}/..")


### PR DESCRIPTION
* Git submodules don't create a directory called `.git`, but a file which points to a parent repo directory.
* We still want `aid` to work with submodules.